### PR TITLE
fix: update requirements.txt with missing dependencies and fix installation errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
-requests-html==0.10.0
-lxml==4.9.3
-lxml_html_clean==0.1.1
-urllib3==2.0.7
-json-lib==0.5.1
-argparse==1.4.0
-tqdm == 4.67.1
-aiohttp
-asyncio
-phonenumbers
+aiohttp>=3.9.0
+beautifulsoup4>=4.12.0
+brotli>=1.1.0
+lxml>=4.9.0
+lxml_html_clean>=0.1.1
+pandas>=2.0.0
+phonenumbers>=8.13.0
+requests>=2.31.0
+requests-html>=0.10.0
+tqdm>=4.66.0
+urllib3>=2.0.0
+


### PR DESCRIPTION
### Summary of Changes

This PR resolves installation errors and missing runtime dependencies in `requirements.txt`:

1. **Remove obsolete package `json-lib==0.5.1`**:
   - `json-lib` is an unmaintained C extension that fails to build/install on modern Python versions (e.g. 3.10+). Python's standard library `json` is used instead.

2. **Add missing dependencies used in `main.py` pipeline**:
   - `pandas>=2.0.0`: Required by `pipeline/orchestrator.py` for pipeline dataframe operations.
   - `beautifulsoup4>=4.12.0`: Required by `enrichment/web_scraper.py` for lead website parsing.

3. **Add `brotli>=1.1.0`**:
   - `mapScraper/placesCrawlerV2.py` sends `Accept-Encoding: gzip, deflate, br`. Without `brotli`, `aiohttp` raises `400 Can not decode content-encoding: brotli (br)`.

4. **Clean up standard library and redundant packages**:
   - Removed `argparse==1.4.0` and `asyncio` as they are built into standard library Python.
   - Relaxed overly rigid version pins to support modern Python (3.10 through 3.14).

---

### Verification
- Tested clean installation in a fresh Python virtual environment